### PR TITLE
Add support ref-forwarding & fix issues 133,150

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ react-native link react-native-text-input-mask
 import TextInputMask from 'react-native-text-input-mask';
 ...
 <TextInputMask
-  refInput={ref => { this.input = ref }}
+  ref={ref => { this.input = ref }}
   onChangeText={(formatted, extracted) => {
     console.log(formatted) // +1 (123) 456-78-90
     console.log(extracted) // 1234567890

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, forwardRef } from 'react'
 
 import {
   TextInput,
@@ -10,9 +10,8 @@ import {
 const mask = NativeModules.RNTextInputMask.mask
 const unmask = NativeModules.RNTextInputMask.unmask
 const setMask = NativeModules.RNTextInputMask.setMask
-export { mask, unmask, setMask }
 
-export default class TextInputMask extends Component {
+class TextInputMask extends Component {
   static defaultProps = {
     maskDefaultValue: true,
   }
@@ -34,7 +33,7 @@ export default class TextInputMask extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.mask && (this.props.value !== nextProps.value)) {
       mask(this.props.mask, '' + nextProps.value, text =>
       this.input && this.input.setNativeProps({ text })
@@ -69,3 +68,22 @@ export default class TextInputMask extends Component {
     />);
   }
 }
+
+const ForwardedTextInputMask = (props, ref) => (
+  <TextInputMask
+    {...props}
+    refInput={textInputInstance => {
+      if (ref) {
+        if (typeof ref === "function") {
+          ref(textInputInstance);
+        } else if (typeof ref === "object") {
+          ref.current = textInputInstance;
+        }
+      }
+    }}
+  />
+);
+
+export { mask, unmask, setMask };
+
+export default forwardRef(ForwardedTextInputMask);

--- a/index.js
+++ b/index.js
@@ -69,9 +69,13 @@ class TextInputMask extends Component {
   }
 }
 
-const ForwardedTextInputMask = (props, ref) => (
+const ForwardedTextInputMask = ({ mask, ...props }, ref) => (
   <TextInputMask
+    // Force remount an component, to fix problem with
+    // https://github.com/react-native-community/react-native-text-input-mask/issues/150
+    key={mask}
     {...props}
+    mask={mask}
     refInput={textInputInstance => {
       if (ref) {
         if (typeof ref === "function") {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const ForwardedTextInputMask = ({ mask, ...props }, ref) => (
       if (ref) {
         if (typeof ref === "function") {
           ref(textInputInstance);
-        } else if (typeof ref === "object") {
+        } else if (typeof ref === "object" && ref != null) {
           ref.current = textInputInstance;
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "devDependencies": {
     "@react-native-community/eslint-config": "0.0.2"
   },
+  "peerDependencies": {
+    "react": ">=16.3.0"
+  },
   "author": "Ivan Zotov",
   "bugs": {
     "url": "https://github.com/react-native-community/react-native-text-input-mask/issues"


### PR DESCRIPTION
# Summary

Pull request solve:

1) https://github.com/react-native-community/react-native-text-input-mask/issues/133
2) Support of ref object `{ current: x}`

## Test Plan

### What's required for testing (prerequisites)?

**1) Support ref-forwarding:**

```js
<TextInputMask  ref={console.log} />;

// ----------------------------
const ref = useRef(null);

useEffect(() => {
  console.log("shouldn't null: ", ref);
},[ref]);

<TextInputMask  ref={ref} />;
```


**2) Warning about** `componentWillReceiveProps`:

- Create a new project `react-native init`
- Install module with fix `yarn add retyui/react-native-text-input-mask#support-refs`
- Add `<TextInputMask mask={"+1 ([000]) [000] [00] [00]"} />` to App.js
- Run an application
- Enable Debug and check there is not warning message in a console panel



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
