### PR TITLE
Fix package installation and autolinking detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "3.0.0",
   "description": "Text input mask for React Native.",
   "files": [
-    "dist"
+    "dist",
+    "android",
+    "ios",
+    "react-native-text-input-mask.podspec"
   ],
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "main": "index.tsx",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/react-native-text-input-mask"
@@ -20,8 +22,7 @@
     "ios"
   ],
   "scripts": {
-    "prepublish": "npx tsc",
-    "postinstall": "npx tsc"
+    "prepublish": "npx tsc"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "0.0.2",

--- a/react-native-text-input-mask.podspec
+++ b/react-native-text-input-mask.podspec
@@ -24,6 +24,5 @@ Pod::Spec.new do |s|
     s.requires_arc  = true
     s.swift_version = "5.0"
     s.dependency 'React-Core'
-    s.dependency 'React-RCTText'
     s.dependency 'InputMask', '~> 6.1.0'
   end


### PR DESCRIPTION
- Declare android, ios and podspec files in `package.json` to fix react-native [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
This fix #185 #189 #191  `Module AppRegistry is not a registered callable module`
Might be related to #190 (not sure as I am not using yarn)
- Remove tsc as postinstall script and use `index.tsx` as main entry in `package.json` instead of using compiled `dist/index.js`
Fix installation process  #186 for project that don't use typescript or with a not compatible configuration
- Remove `'React-RCTText'` dependency in podspec. It does not seems required at all, as it is already a dependency of React. 
Fix `pod install` errors. No need to add `use_frameworks!` in `PodFile` anymore.