### PR TITLE
fix: propagate `textDidChangeNotification` and `editingChanged` events further

### DIFF
--- a/ios/TextInputMask.swift
+++ b/ios/TextInputMask.swift
@@ -16,7 +16,7 @@ class TextInputMask: NSObject, RCTBridgeModule, MaskedTextFieldDelegateListener 
     }
 
     var bridge: RCTBridge!
-    var masks: [String: MaskedTextFieldDelegate] = [:]
+    var masks: [String: NotifyingMaskedTextFieldDelegate] = [:]
 
     var listeners: [String: MaskedTextFieldDelegateListener] = [:]
 
@@ -45,7 +45,7 @@ class TextInputMask: NSObject, RCTBridgeModule, MaskedTextFieldDelegateListener 
                 let rightToLeft = options["rightToLeft"] as? Bool ?? false
                 var affinityCalculationStrategy = AffinityCalculationStrategy.forString(rawValue: options["affinityCalculationStrategy"] as? String)
                 
-                let maskedDelegate = MaskedTextFieldDelegate(primaryFormat: mask, autocomplete: autocomplete, autoskip: autoskip, affineFormats: affineFormats, customNotations: customNotations) { (_, value, complete) in
+                let maskedDelegate = NotifyingMaskedTextFieldDelegate(primaryFormat: mask, autocomplete: autocomplete, autoskip: autoskip, affineFormats: affineFormats, customNotations: customNotations) { (_, value, complete) in
                     // trigger onChange directly to avoid trigger a second evaluation in native code (causes issue with some input masks like [00] {/} [00]
                     let textField = textView as! UITextField
                     view.onChange?([
@@ -66,6 +66,20 @@ class TextInputMask: NSObject, RCTBridgeModule, MaskedTextFieldDelegateListener 
 }
 
 class MaskedRCTBackedTextFieldDelegateAdapter : RCTBackedTextFieldDelegateAdapter, MaskedTextFieldDelegateListener {}
+
+class NotifyingMaskedTextFieldDelegate: MaskedTextFieldDelegate {
+    override func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        defer {
+            NotificationCenter.default.post(name: UITextField.textDidChangeNotification, object: textField)
+            textField.sendActions(for: .editingChanged)
+        }
+        return super.textField(textField, shouldChangeCharactersIn: range, replacementString: string)
+    }
+}
 
 extension Dictionary where Key == String, Value == Any {
     func toNotation() -> Notation {


### PR DESCRIPTION
Right now if I add another listener for `editingChanged` event -> I'll not get any updates.

It happens because of [problem described here](https://github.com/RedMadRobot/input-mask-ios?tab=readme-ov-file#uitextfieldtextdidchange-notification-and-target-action-editingchanged-event) (a particular issue with discussion was in https://github.com/RedMadRobot/input-mask-ios/issues/12 but it's in Russian language).

In general author of `input-mask-ios` suggest to add a custom delegate with `onEditingChanged` callback. However for 3rd party libraries (such as [react-native-keyboard-controller](https://github.com/kirillzyusko/react-native-keyboard-controller) it could be a problematic approach, because I need to set a callback to `textField` delegate - but for that I need to know the interface/protocol of this delegate, and I can not import this protocol from `react-native-text-input-mask` - in order to do this I need to make a dependency on `react-native-text-input-mask` in Podfile, but it should be optional dependency and I feel like it makes an approach very complicated without explicit benefits).

So I went with an approach where we directly re-send events 👀

Feel free to suggest other alternatives if you have them!

Also for reference I'm attaching an original PR with fix from `react-native-keyboard-controller`: https://github.com/kirillzyusko/react-native-keyboard-controller/pull/341